### PR TITLE
Chore: use shared workflow files (fix #31)

### DIFF
--- a/.github/workflows/addtomainproject.yml
+++ b/.github/workflows/addtomainproject.yml
@@ -1,5 +1,4 @@
 name: Add to main project
-
 on:
   issues:
     types:
@@ -7,13 +6,8 @@ on:
   pull_request:
     types:
       - opened
-
+  workflow_dispatch:
 jobs:
   add-to-project:
-    name: Add to main project
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/add-to-project@v0.1.0
-        with:
-          project-url: https://github.com/orgs/cgkineo/projects/3/views/1
-          github-token: ${{ secrets.ADDTOPROJECT_TOKEN }}
+    uses: cgkineo/.github/.github/workflows/addtomainproject.yml@master
+    secrets: inherit

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -3,23 +3,8 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 jobs:
   release:
-    name: Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 'lts/*'
-      - name: Install dependencies
-        run: npm ci
-      - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+    uses: cgkineo/.github/.github/workflows/releases.yml@master
+    secrets: inherit


### PR DESCRIPTION
Fixes #31

### Update
- Migrate `addtomainproject.yml` and `releases.yml` to the reusable, shared workflows in `cgkineo/.github` (caller-only; `workflow_dispatch` enabled).

Posted via collaboration with Claude Code